### PR TITLE
feat: add solution 2,3 of week8

### DIFF
--- a/week8 - backtracking/gyu/1. 피로도.py
+++ b/week8 - backtracking/gyu/1. 피로도.py
@@ -1,0 +1,16 @@
+def backtracking(k, dungeons, check, count):
+    ans = count
+    for i in range(len(dungeons)):
+        if check[i]:
+            continue
+        
+        if k >= dungeons[i][0]:
+            check[i] = True
+            ans = max(ans, backtracking(k - dungeons[i][1], dungeons, check, count + 1))
+            check[i] = False
+
+    return ans
+
+def solution(k, dungeons):
+    check = [False] * len(dungeons)
+    return backtracking(k, dungeons, check, 0)

--- a/week8 - backtracking/gyu/2. N-Queen.py
+++ b/week8 - backtracking/gyu/2. N-Queen.py
@@ -1,0 +1,24 @@
+def backtracking(n, y, cols, dia1, dia2, count):
+    if n == y:
+        return count+1
+    
+    ans = count
+    for i in range(n):
+        if cols[i] or dia1[i + y] or dia2[n - i + y]:
+            continue
+        cols[i] = True
+        dia1[i + y] = True
+        dia2[n - i + y] = True
+        ans += backtracking(n, y + 1, cols, dia1, dia2,count)
+        cols[i] = False
+        dia1[i + y] = False
+        dia2[n - i + y] = False
+    
+    return ans
+
+def solution(n):
+    cols = [False] * n
+    dia1 = [False] * (n * 2)
+    dia2 = [False] * (n * 2)
+    
+    return backtracking(n, 0, cols, dia1, dia2, 0)

--- a/week8 - backtracking/gyu/3. 양궁대회.py
+++ b/week8 - backtracking/gyu/3. 양궁대회.py
@@ -1,0 +1,47 @@
+import copy
+# import sys
+# sys.setrecursionlimit(10**9)
+brian_array = [0] * 11
+brian_max = 0
+
+def backtracking(n, k,me,info):
+    if n == 0:
+        apeach = 0
+        brian = 0
+        for i in range(len(info)):
+            if me[i] > info[i]:
+                brian += 10 - i
+            elif info[i] != 0:
+                apeach += 10 - i
+        
+        global brian_array
+        global brian_max
+        if brian > apeach:
+            if brian - apeach > brian_max:
+                brian_max = brian - apeach
+                brian_array = copy.deepcopy(me)
+            elif brian - apeach == brian_max:
+                for i in range(len(info)):
+                    if me[10-i] == brian_array[10-i]:
+                        continue
+                    
+                    if me[10-i] > brian_array[10-i]:
+                        brian_array = copy.deepcopy(me)
+                    break
+        return
+
+    if k >= len(info):
+        return
+                
+    for i in range(0,n+1):
+        me[k] += i
+        backtracking(n-i, k+1, me, info)
+        me[k] -= i
+
+def solution(n, info):    
+    backtracking(n, 0,[0] * len(info), info)
+    global brian_array
+    global brian_max
+    if brian_max == 0:
+        return [-1]
+    return brian_array


### PR DESCRIPTION
# 1. 피도로
흔한 백트래킹을 사용하는 문제인데, `check`배열을 사용하여 이미 사용했던 던전을 표시해준다.

# 2. N-Queen
백트래킹으로 하나씩 놓으면서 가능한 모든 조합을 찾으면 된다. 여기서 아이디어는 매번 상하좌우, 대각선을 찾기 귀찮으니 다음과 같이, 단축된 배열을 사용하는 것이다. 

가령 행을 하나씩 골라 queen을 놓는다고 하면 다음과 같다.
```
   0  1  2  3 
0 Q
1 
2
3
```
(0,0)에 놓았으므로 0번째 행은 이제 아무것도 못 놓는다. 따라서 다음 행으로 넘어가는데, 잘 생각해보면 '열' 역시도 못가는 부분이 있다. 이를 표시해줄 때 간단하게, '열' 배열로만으로 표현할 수 있게 되는 것이다.

| 0|1|2|3|
|--|---|---|---|
|True|False|False|False|

0열에 queen이 있었으므로 True이고 0열에는 아무 queen도 못놓는다. 따라서, false인 부분에만 queen이 들어갈 수 있다.

더불어 대각선 검사도 해야하는데, 이 경우에도 대각선 배열을 사용하면 된다.
```
      0    1    2    3
---------------
0 |  0    1    2     3
1 |   1    2    3    4   
2 |  2   3    4     5
3 |  3   4    5     6
```
행과 열을 더해서 인덱스로 사용하면 된다.

따라서 다음과 같이 정의하고 사용 할 수 있다.
```py
dia1 = [False] * (n * 2)
dia2 = [False] * (n * 2)
...
dia1[x + y] = False
dia2[n - x + y] = False
```
위의 그림이 dial1이고 dial2는 반대편 대각선으로 생각해면 된다.

# 3. 양궁대회
N queen처럼 각 점수(10~0) 마다의 화살 수를 백트래킹으로 조합하여 구해주면 가능하다. 사실상 조건을 다루는게 더 까다로웠는데,  둘 다 화살을 안쐈다면 둘 다 점수가 부여되지 않는다. 그러나 구현할 때는 각 점수의 화살 수 비교 시 `==`으로 만 비교하여 어피치에게 점수를 더 부여하는 오류가 있었다. 이것 외에는 일반적인 백트래킹 문제이다.

참고로 python에서는  `combinations_with_replacement(list, n)`을 사용하면 쉽게 풀린다. 이 함수를 사용하면 `list`중 `n`개를 중복을 허용하여 조합을 뽑아낸다. 가령 다음과 같다.

```py
from itertools import combinations_with_replacement, combinations

for combi in combinations_with_replacement(range(11), 5):
    print(combi)
```

결과는 다음과 같다.
```sh
(0,0,0,0,0)
...
(7, 8, 8, 8, 9)
(7, 8, 8, 8, 10)
(7, 8, 8, 9, 9)
...
(9, 10, 10, 10, 10)
(10, 10, 10, 10, 10)
```

반면 `combinations`는 사용하면 중복을 허용하지 않기 때문에 다음과 같이 나온다.
```pu
from itertools import combinations_with_replacement, combinations

for combi in combinations(range(11), 5):
    print(combi)
```

결과는 아래와 같다.
```sh
(0, 1, 2, 3, 4)
(0, 1, 2, 3, 5)
(0, 1, 2, 3, 6)
...
(5, 7, 8, 9, 10)
(6, 7, 8, 9, 10)
```
